### PR TITLE
fix: use correct native linux library names

### DIFF
--- a/Source/SpiderEye.Linux/Native/GLib.cs
+++ b/Source/SpiderEye.Linux/Native/GLib.cs
@@ -6,9 +6,9 @@ namespace SpiderEye.Linux.Native
 {
     internal static class GLib
     {
-        private const string GLibNativeDll = "libglib-2.0.so";
-        private const string GObjectNativeDll = "libgobject-2.0.so";
-        private const string GIONativeDll = "libgio-2.0.so";
+        private const string GLibNativeDll = "libglib-2.0.so.0";
+        private const string GObjectNativeDll = "libgobject-2.0.so.0";
+        private const string GIONativeDll = "libgio-2.0.so.0";
 
         [DllImport(GLibNativeDll, EntryPoint = "g_malloc", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr Malloc(UIntPtr size);

--- a/Source/SpiderEye.Linux/Native/Gdk.cs
+++ b/Source/SpiderEye.Linux/Native/Gdk.cs
@@ -5,7 +5,7 @@ namespace SpiderEye.Linux.Native
 {
     internal static class Gdk
     {
-        private const string GdkNativeDll = "libgdk-3.so";
+        private const string GdkNativeDll = "libgdk-3.so.0";
 
         public static class Pixbuf
         {

--- a/Source/SpiderEye.Linux/Native/Gtk.cs
+++ b/Source/SpiderEye.Linux/Native/Gtk.cs
@@ -6,7 +6,7 @@ namespace SpiderEye.Linux.Native
 {
     internal static class Gtk
     {
-        private const string GtkNativeDll = "libgtk-3.so";
+        private const string GtkNativeDll = "libgtk-3.so.0";
 
         public static class Widget
         {

--- a/Source/SpiderEye.Linux/Native/LibNotify.cs
+++ b/Source/SpiderEye.Linux/Native/LibNotify.cs
@@ -5,7 +5,7 @@ namespace SpiderEye.Linux.Native
 {
     internal static class LibNotify
     {
-        private const string LibNotifyDll = "libnotify";
+        private const string LibNotifyDll = "libnotify.so.4";
 
         [DllImport(LibNotifyDll, EntryPoint = "notify_init", CallingConvention = CallingConvention.Cdecl)]
         public static extern bool Init(string app_name);

--- a/Source/SpiderEye.Linux/Native/WebKit.cs
+++ b/Source/SpiderEye.Linux/Native/WebKit.cs
@@ -6,8 +6,8 @@ namespace SpiderEye.Linux.Native
 {
     internal static class WebKit
     {
-        private const string WebkitNativeDll = "libwebkit2gtk-4.0.so";
-        private const string JavaScriptCoreNativeDll = "libjavascriptcoregtk-4.0.so";
+        private const string WebkitNativeDll = "libwebkit2gtk-4.0.so.37";
+        private const string JavaScriptCoreNativeDll = "libjavascriptcoregtk-4.0.so.18";
 
         public static class Manager
         {


### PR DESCRIPTION
previous library names required the dev versions to be installed